### PR TITLE
Add Conda environment support to `get_search_paths_from_envs`

### DIFF
--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -11,8 +11,12 @@ def get_search_paths_from_envs(env_list):
         pathlib.Path(f) if (env != "AMENT_PREFIX_PATH") else pathlib.Path(f) / "share"
         for env in env_list if os.getenv(env) is not None
         for f in os.getenv(env).split(os.pathsep)
-    ]
-
+    ] or (
+        [pathlib.Path(os.getenv("CONDA_PREFIX")) / "share"]
+        if os.getenv("CONDA_PREFIX")
+        else []
+    )
+    
 def pathlist_list_to_string(path_list):
     return ' '.join(str(path) for path in path_list)
 


### PR DESCRIPTION
This PR enhances the `get_search_paths_from_envs` function to provide support for Conda environments. During testing, it was discovered that when running within a Conda environment inside a Docker container, the function returned an empty list even when the paths existed. This behavior occurred because none of the environment variables specified in `env_list` were considered within the Conda environment when installing ergocub-software` with conda.

In order to provide support for this scenario, I added conditional checks for the presence of the `CONDA_PREFIX` environment variable which is used when available appending the corresponding `share` directory path to the search paths list.

For testing purposes, the Docker image used in this PR can be found on Docker Hub:

```
docker pull flferr/evogym:latest
```

C.C. @traversaro 