### PR TITLE
Enhance and refactor URIs resolving logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     
     - name: Run the Python tests
       shell: bash -l {0}
-      run: pytest
+      run: pytest --capture=no
 
     # This test requires the conda-forge::icub-models,
     # robotology::ergocub-software and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,13 @@ jobs:
         resolve-robotics-uri-py package://ergoCub/robots/ergoCubSN000/model.urdf
         resolve-robotics-uri-py package://moveit_resources_panda_description/urdf/panda.urdf
         ! resolve-robotics-uri-py package://this/file/does/not/exist
+    - name: Check command line helper (Ubuntu and macOS)
+      if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+      shell: bash -l {0}
+      run: |
+        mkdir -p /tmp/folder/ && touch "/tmp/folder/file with spaces.txt"
+        mkdir -p /tmp/folder/ && touch "/tmp/folder/file_without_spaces.txt"
+        resolve-robotics-uri-py "file:///tmp/folder/file_without_spaces.txt"
+        resolve-robotics-uri-py "file:///tmp/folder/file with spaces.txt"
+        resolve-robotics-uri-py "file:/tmp/folder/file_without_spaces.txt"
+        resolve-robotics-uri-py "file:/tmp/folder/file with spaces.txt"

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,4 +59,4 @@ all =
 
 [tool:pytest]
 addopts = -rsxX -v --strict-markers
-testpaths = tests
+testpaths = test

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -23,6 +23,19 @@ def pathlist_list_to_string(path_list):
 
 
 def resolve_robotics_uri(uri: str) -> pathlib.Path:
+    """
+    Resolve a robotics URI to an absolute filename.
+
+    Args:
+        uri: The URI to resolve.
+
+    Returns:
+        The absolute filename corresponding to the URI.
+
+    Raises:
+        FileNotFoundError: If no file corresponding to the URI is found.
+    """
+
     # List of environment variables to consider, see:
     # * https://github.com/robotology/idyntree/issues/291
     # * https://github.com/gazebosim/sdformat/issues/1234
@@ -86,11 +99,13 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
 
     for folder in set(get_search_paths_from_envs(env_list)):
 
+        # Join the folder from environment variable and the URI path
         candidate_file_name = folder / uri_path
 
         if not candidate_file_name.is_file():
             continue
 
+        # Skip if the file is already in the list
         if candidate_file_name not in model_filenames:
             model_filenames.append(candidate_file_name)
 

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -4,6 +4,9 @@ import pathlib
 import sys
 import warnings
 
+# Supported URI schemes
+SupportedSchemes = {"file", "package", "model"}
+
 
 # Function inspired from https://github.com/ami-iit/robot-log-visualizer/pull/51
 def get_search_paths_from_envs(env_list):
@@ -57,7 +60,7 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     # * model://:   SDF-style model URI
     # * package://: ROS-style package URI
     #
-    if parsed_uri.scheme not in {"file", "package", "model"}:
+    if parsed_uri.scheme not in SupportedSchemes:
         raise FileNotFoundError(
             f'Passed URI "{uri}" use non-supported scheme {parsed_uri.scheme}'
         )
@@ -104,14 +107,21 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Utility resolve a robotics URI (file://, model://, package://) to an absolute filename."
+        description="Utility resolve a robotics URI ({}) to an absolute filename.".format(
+            ", ".join(f"{scheme}://" for scheme in SupportedSchemes)
+        )
     )
-    parser.add_argument("uri", metavar="uri", type=str, help="URI to resolve")
+    parser.add_argument("uri", metavar="URI", type=str, help="URI to resolve")
 
     args = parser.parse_args()
-    result = resolve_robotics_uri(args.uri)
 
-    print(result)
+    try:
+        result = resolve_robotics_uri(args.uri)
+    except FileNotFoundError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
+
+    print(result, file=sys.stdout)
     sys.exit(0)
 
 

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -2,19 +2,22 @@ import argparse
 import os
 import pathlib
 import sys
-from typing import List
 import warnings
+
 
 # Function inspired from https://github.com/ami-iit/robot-log-visualizer/pull/51
 def get_search_paths_from_envs(env_list):
     return [
         pathlib.Path(f) if (env != "AMENT_PREFIX_PATH") else pathlib.Path(f) / "share"
-        for env in env_list if os.getenv(env) is not None
+        for env in env_list
+        if os.getenv(env) is not None
         for f in os.getenv(env).split(os.pathsep)
     ]
 
+
 def pathlist_list_to_string(path_list):
-    return ' '.join(str(path) for path in path_list)
+    return " ".join(str(path) for path in path_list)
+
 
 def resolve_robotics_uri(uri: str) -> pathlib.Path:
     # List of environment variables to consider, see:
@@ -29,7 +32,14 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     # * SDF_PATH: Used in sdformat
     # * IGN_GAZEBO_RESOURCE_PATH: Used in Ignition Gazebo <= 7
     # * GZ_SIM_RESOURCE_PATH: Used in Gazebo Sim >= 7
-    env_list = ["GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH", "AMENT_PREFIX_PATH", "SDF_PATH", "IGN_GAZEBO_RESOURCE_PATH", "GZ_SIM_RESOURCE_PATH"]
+    env_list = [
+        "GAZEBO_MODEL_PATH",
+        "ROS_PACKAGE_PATH",
+        "AMENT_PREFIX_PATH",
+        "SDF_PATH",
+        "IGN_GAZEBO_RESOURCE_PATH",
+        "GZ_SIM_RESOURCE_PATH",
+    ]
 
     # If the URI has no scheme, use by default the file://
     if "://" not in uri:
@@ -37,6 +47,8 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
 
     # Get scheme from URI
     from urllib.parse import urlparse
+
+    # Parse the URI
     parsed_uri = urlparse(uri)
 
     # We only support the following URI schemes at the moment:
@@ -46,7 +58,9 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     # * package://: ROS-style package URI
     #
     if parsed_uri.scheme not in {"file", "package", "model"}:
-        raise FileNotFoundError(f"Passed URI \"{uri}\" use non-supported scheme {parsed_uri.scheme}")
+        raise FileNotFoundError(
+            f'Passed URI "{uri}" use non-supported scheme {parsed_uri.scheme}'
+        )
 
     if parsed_uri.scheme == "file":
         # Strip the URI scheme, keep the absolute path to the file (with trailing /)
@@ -89,7 +103,9 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Utility resolve a robotics URI (file://, model://, package://) to an absolute filename.")
+    parser = argparse.ArgumentParser(
+        description="Utility resolve a robotics URI (file://, model://, package://) to an absolute filename."
+    )
     parser.add_argument("uri", metavar="uri", type=str, help="URI to resolve")
 
     args = parser.parse_args()
@@ -97,6 +113,7 @@ def main():
 
     print(result)
     sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -61,22 +61,25 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     # * package://: ROS-style package URI
     #
     if parsed_uri.scheme not in SupportedSchemes:
-        raise FileNotFoundError(
-            f'Passed URI "{uri}" use non-supported scheme {parsed_uri.scheme}'
-        )
-
-    if parsed_uri.scheme == "file":
-        # Strip the URI scheme, keep the absolute path to the file (with trailing /)
-        uri_path = pathlib.Path(uri.replace(f"{parsed_uri.scheme}:/", ""))
-
-        if not uri_path.is_file():
-            msg = "resolve-robotics-uri-py: No file corresponding to uri '{}' found"
-            raise FileNotFoundError(msg.format(uri))
-
-        return uri_path
+        msg = "resolve-robotics-uri-py: Passed URI '{}' use non-supported scheme '{}'"
+        raise FileNotFoundError(msg.format(uri, parsed_uri.scheme))
 
     # Strip the URI scheme
     uri_path = uri.replace(f"{parsed_uri.scheme}://", "")
+
+    if parsed_uri.scheme == "file":
+        # Ensure the URI path is absolute
+        uri_path = uri_path if uri_path.startswith("/") else f"/{uri_path}"
+
+        # Create the file path
+        uri_file_path = pathlib.Path(uri_path)
+
+        # Check that the file exists
+        if not uri_file_path.is_file():
+            msg = "resolve-robotics-uri-py: No file corresponding to URI '{}' found"
+            raise FileNotFoundError(msg.format(uri))
+
+        return uri_file_path
 
     # List of matching resources found
     model_filenames = []

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -113,19 +113,20 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     # Strip the URI scheme
     uri_path = uri.replace(f"{parsed_uri.scheme}://", "")
 
+    # Process file:// separately from the other schemes
     if parsed_uri.scheme == "file":
         # Ensure the URI path is absolute
         uri_path = uri_path if uri_path.startswith("/") else f"/{uri_path}"
 
-        # Create the file path
-        uri_file_path = pathlib.Path(uri_path)
+        # Create the file path, resolving symlinks and '..'
+        uri_file_path = pathlib.Path(uri_path).resolve()
 
         # Check that the file exists
         if not uri_file_path.is_file():
             msg = "resolve-robotics-uri-py: No file corresponding to URI '{}' found"
             raise FileNotFoundError(msg.format(uri))
 
-        return uri_file_path
+        return uri_file_path.resolve()
 
     # List of matching resources found
     model_filenames = []
@@ -134,6 +135,9 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
 
         # Join the folder from environment variable and the URI path
         candidate_file_name = folder / uri_path
+
+        # Expand or resolve the file path (symlinks and ..)
+        candidate_file_name = candidate_file_name.resolve()
 
         if not candidate_file_name.is_file():
             continue
@@ -153,7 +157,7 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
 
     if len(model_filenames) >= 1:
         assert model_filenames[0].exists()
-        return pathlib.Path(model_filenames[0])
+        return pathlib.Path(model_filenames[0]).resolve()
 
 
 def main():

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -67,7 +67,7 @@ def get_search_paths_from_envs(env_list: Iterable[str]) -> list[pathlib.Path]:
     return existing_search_paths
 
 
-def pathlist_list_to_string(path_list):
+def pathlist_list_to_string(path_list: Iterable[str | pathlib.Path]) -> str:
     return " ".join(str(path) for path in path_list)
 
 

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -39,11 +39,13 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     from urllib.parse import urlparse
     parsed_uri = urlparse(uri)
 
-    # We only support at the moment:
-    # file:// scheme: to pass a file path directly
-    # package:// : ROS-style package URI
-    # model:// : SDF-style model URI
-    if parsed_uri.scheme not in ["file", "package", "model"]:
+    # We only support the following URI schemes at the moment:
+    #
+    # * file://:    to pass an absolute file path directly
+    # * model://:   SDF-style model URI
+    # * package://: ROS-style package URI
+    #
+    if parsed_uri.scheme not in {"file", "package", "model"}:
         raise FileNotFoundError(f"Passed URI \"{uri}\" use non-supported scheme {parsed_uri.scheme}")
 
     model_filenames = []

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -31,9 +31,9 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     # * GZ_SIM_RESOURCE_PATH: Used in Gazebo Sim >= 7
     env_list = ["GAZEBO_MODEL_PATH", "ROS_PACKAGE_PATH", "AMENT_PREFIX_PATH", "SDF_PATH", "IGN_GAZEBO_RESOURCE_PATH", "GZ_SIM_RESOURCE_PATH"]
 
-    # Preliminary step: if there is no scheme, we just consider this a path and we return it as it is
+    # If the URI has no scheme, use by default the file://
     if "://" not in uri:
-        return pathlib.Path(uri)
+        uri = f"file://{uri}"
 
     # Get scheme from URI
     from urllib.parse import urlparse

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -7,6 +7,32 @@ import warnings
 # Supported URI schemes
 SupportedSchemes = {"file", "package", "model"}
 
+# Environment variables in the search path.
+#
+# * https://github.com/robotology/idyntree/issues/291
+# * https://github.com/gazebosim/sdformat/issues/1234
+#
+# AMENT_PREFIX_PATH is the only "special" as we need to add
+# "share" after each value, see https://github.com/stack-of-tasks/pinocchio/issues/1520
+#
+# This list specify the origin of each env variable:
+#
+# * AMENT_PREFIX_PATH:        Used in ROS2
+# * GAZEBO_MODEL_PATH:        Used in Gazebo Classic
+# * GZ_SIM_RESOURCE_PATH:     Used in Gazebo Sim >= 7
+# * IGN_GAZEBO_RESOURCE_PATH: Used in Ignition Gazebo <= 7
+# * ROS_PACKAGE_PATH:         Used in ROS1
+# * SDF_PATH:                 Used in sdformat
+#
+SupportedEnvVars = {
+    "AMENT_PREFIX_PATH",
+    "GAZEBO_MODEL_PATH",
+    "GZ_SIM_RESOURCE_PATH",
+    "IGN_GAZEBO_RESOURCE_PATH",
+    "ROS_PACKAGE_PATH",
+    "SDF_PATH",
+}
+
 
 # Function inspired from https://github.com/ami-iit/robot-log-visualizer/pull/51
 def get_search_paths_from_envs(env_list):
@@ -35,27 +61,6 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     Raises:
         FileNotFoundError: If no file corresponding to the URI is found.
     """
-
-    # List of environment variables to consider, see:
-    # * https://github.com/robotology/idyntree/issues/291
-    # * https://github.com/gazebosim/sdformat/issues/1234
-    # AMENT_PREFIX_PATH is the only "special" as we need to add
-    # "share" after each value, see https://github.com/stack-of-tasks/pinocchio/issues/1520
-    # This list specify the origin of each env variable:
-    # * GAZEBO_MODEL_PATH: Used in Gazebo Classic
-    # * ROS_PACKAGE_PATH: Used in ROS1
-    # * AMENT_PREFIX_PATH: Used in ROS2
-    # * SDF_PATH: Used in sdformat
-    # * IGN_GAZEBO_RESOURCE_PATH: Used in Ignition Gazebo <= 7
-    # * GZ_SIM_RESOURCE_PATH: Used in Gazebo Sim >= 7
-    env_list = [
-        "GAZEBO_MODEL_PATH",
-        "ROS_PACKAGE_PATH",
-        "AMENT_PREFIX_PATH",
-        "SDF_PATH",
-        "IGN_GAZEBO_RESOURCE_PATH",
-        "GZ_SIM_RESOURCE_PATH",
-    ]
 
     # If the URI has no scheme, use by default the file://
     if "://" not in uri:
@@ -97,7 +102,7 @@ def resolve_robotics_uri(uri: str) -> pathlib.Path:
     # List of matching resources found
     model_filenames = []
 
-    for folder in set(get_search_paths_from_envs(env_list)):
+    for folder in set(get_search_paths_from_envs(SupportedEnvVars)):
 
         # Join the folder from environment variable and the URI path
         candidate_file_name = folder / uri_path

--- a/test/test_resolve_robotics_uri_py.py
+++ b/test/test_resolve_robotics_uri_py.py
@@ -1,6 +1,10 @@
 import resolve_robotics_uri_py
 import pytest
 
+
 def test_non_existing_file():
+
     with pytest.raises(FileNotFoundError):
-        resolve_robotics_uri_py.resolve_robotics_uri("package://this/package/and/file/does/not.exist")
+        resolve_robotics_uri_py.resolve_robotics_uri(
+            "package://this/package/and/file/does/not.exist"
+        )

--- a/test/test_resolve_robotics_uri_py.py
+++ b/test/test_resolve_robotics_uri_py.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import pathlib
+import sys
 import tempfile
 from typing import ContextManager
 
@@ -153,3 +154,9 @@ def test_scheme_file():
         path_of_file = resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
         assert path_of_file == path_of_file.resolve()
         assert path_of_file == temp_name
+
+    # Try to find an existing file (the Python executable) without any file:/ scheme
+    path_of_python_executable = resolve_robotics_uri_py.resolve_robotics_uri(sys.executable)
+    assert path_of_python_executable == pathlib.Path(sys.executable)
+
+

--- a/test/test_resolve_robotics_uri_py.py
+++ b/test/test_resolve_robotics_uri_py.py
@@ -1,10 +1,136 @@
-import resolve_robotics_uri_py
+import contextlib
+import os
+import pathlib
+import tempfile
+from typing import ContextManager
+
 import pytest
 
+import resolve_robotics_uri_py
 
-def test_non_existing_file():
 
+def clear_env_vars():
+    for env_var in resolve_robotics_uri_py.resolve_robotics_uri_py.SupportedEnvVars:
+        _ = os.environ.pop(env_var, None)
+
+
+@contextlib.contextmanager
+def export_env_var(name: str, value: str) -> ContextManager[None]:
+
+    os.environ[name] = value
+    yield
+    del os.environ[name]
+
+
+# =======================================
+# Test the resolve_robotics_uri functions
+# =======================================
+
+
+@pytest.mark.parametrize("scheme", ["model://", "package://"])
+def test_scoped_uri(scheme: str, env_var_name="GZ_SIM_RESOURCE_PATH"):
+
+    clear_env_vars()
+
+    # Non-existing relative URI path
     with pytest.raises(FileNotFoundError):
-        resolve_robotics_uri_py.resolve_robotics_uri(
-            "package://this/package/and/file/does/not.exist"
-        )
+        uri = f"{scheme}this/package/and/file/does/not.exist"
+        resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+    # Non-existing absolute URI path
+    with pytest.raises(FileNotFoundError):
+        uri = f"{scheme}/this/package/and/file/does/not.exist"
+        resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+    # Existing URI path not in search dirs
+    with pytest.raises(FileNotFoundError):
+        with tempfile.NamedTemporaryFile() as temp:
+            uri = f"{scheme}{temp.name}"
+            resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+    # URI path in top-level search dir
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pathlib.Path(temp_dir).mkdir(exist_ok=True)
+        top_level = pathlib.Path(temp_dir) / "top_level.txt"
+        top_level.touch(exist_ok=True)
+
+        # Existing relative URI path not in search dirs
+        with pytest.raises(FileNotFoundError):
+            uri = f"{scheme}top_level.txt"
+            resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+        # Existing absolute URI path in search dirs
+        with pytest.raises(FileNotFoundError):
+            with export_env_var(name=env_var_name, value=temp_dir):
+                uri = f"{scheme}/top_level.txt"
+                resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+        # Existing relative URI path in search dirs
+        with export_env_var(name=env_var_name, value=temp_dir):
+            uri = f"{scheme}top_level.txt"
+            resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+        # Existing relative URI path in search dirs with multiple paths
+        with export_env_var(name=env_var_name, value=f"/another/dir:{temp_dir}"):
+            uri = f"{scheme}top_level.txt"
+            resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+    # URI path in sub-level search dir
+    with tempfile.TemporaryDirectory() as temp_dir:
+        (pathlib.Path(temp_dir) / "sub").mkdir(exist_ok=True)
+        level1 = pathlib.Path(temp_dir) / "sub" / "level1.txt"
+        level1.touch(exist_ok=True)
+
+        # Existing relative URI path not in search dirs
+        with pytest.raises(FileNotFoundError):
+            uri = f"{scheme}sub/level1.txt"
+            resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+        # Existing absolute URI path in search dirs
+        with pytest.raises(FileNotFoundError):
+            with export_env_var(name=env_var_name, value=temp_dir):
+                uri = f"{scheme}/sub/level1.txt"
+                resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+        # Existing relative URI path in search dirs
+        with export_env_var(name=env_var_name, value=temp_dir):
+            uri = f"{scheme}sub/level1.txt"
+            resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+        # Existing relative URI path in search dirs with multiple paths
+        with export_env_var(name=env_var_name, value=f"/another/dir:{temp_dir}"):
+            uri = f"{scheme}sub/level1.txt"
+            resolve_robotics_uri_py.resolve_robotics_uri(uri)
+
+
+def test_scheme_file():
+
+    clear_env_vars()
+
+    # Non-existing relative URI path
+    with pytest.raises(FileNotFoundError):
+        uri_file = "file://this/file/does/not.exist"
+        resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
+
+    # Non-existing absolute URI path
+    with pytest.raises(FileNotFoundError):
+        uri_file = "file:///this/file/does/not.exist"
+        resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
+
+    # Existing absolute URI path
+    with tempfile.NamedTemporaryFile() as temp:
+        uri_file = f"file://{temp.name}"
+        path_of_file = resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
+        assert path_of_file == pathlib.Path(temp.name)
+
+    # Existing relative URI path (automatic conversion to absolute)
+    with tempfile.NamedTemporaryFile() as temp:
+        uri_file = f"file:/{temp.name}"
+        path_of_file = resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
+        assert path_of_file == pathlib.Path(temp.name)
+
+    # Fallback to file:// with no scheme
+    with tempfile.NamedTemporaryFile() as temp:
+        uri_file = f"{temp.name}"
+        path_of_file = resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
+        assert path_of_file == pathlib.Path(temp.name)

--- a/test/test_resolve_robotics_uri_py.py
+++ b/test/test_resolve_robotics_uri_py.py
@@ -125,28 +125,23 @@ def test_scheme_file():
 
     clear_env_vars()
 
-    # Non-existing relative URI path
-    with pytest.raises(FileNotFoundError):
-        uri_file = "file://this/file/does/not.exist"
-        resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
-
     # Non-existing absolute URI path
     with pytest.raises(FileNotFoundError):
-        uri_file = "file:///this/file/does/not.exist"
+        uri_file = "file://" + "/this/file/does/not.exist"
         resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
 
-    # Existing absolute URI path
+    # Existing absolute URI path with empty authority
     with tempfile.NamedTemporaryFile() as temp:
         temp_name = pathlib.Path(temp.name).resolve(strict=True)
-        uri_file = f"file://{temp.name}"
+        uri_file = "file://" + temp.name
         path_of_file = resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
         assert path_of_file == path_of_file.resolve()
         assert path_of_file == temp_name
 
-    # Existing relative URI path (automatic conversion to absolute)
+    # Existing absolute URI path without authority
     with tempfile.NamedTemporaryFile() as temp:
         temp_name = pathlib.Path(temp.name).resolve(strict=True)
-        uri_file = f"file:/{temp.name}"
+        uri_file = "file:" + temp.name
         path_of_file = resolve_robotics_uri_py.resolve_robotics_uri(uri_file)
         assert path_of_file == path_of_file.resolve()
         assert path_of_file == temp_name


### PR DESCRIPTION
Main changes:

- Resolving now fail if the `file://` path (that is assumed to be absolute) does not exist.
- If the URI has no scheme, `file://` is used by default.

After these changes, the resolved URI is ensured to be an existing file. Before, there were cases in which the resolved path was a non-existent file. Now downstream projects that consume the resulting `pathlib.Path` object can prevent to check the existence of the resolved file.

Furthermore:

- Added new tests.
- Exposed the supported schemes so that downstream projects can check them.
- Exposed the supported environment variables so that downstream projects can check them.

Superseeds #10.  