### PR TITLE
Support passing the name of custom env vars as additional search paths

### DIFF
--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -93,12 +93,13 @@ def resolve_robotics_uri(
         FileNotFoundError: If no file corresponding to the URI is found.
 
     Note:
-        In case `package_dirs` is not provided, the function will look for the file in the
+        By default the function will look for the file in the
         default search paths specified by the environment variables in `SupportedEnvVars`.
-
-        If a given model searches for the meshes in `package://ModelName/meshes/mesh.stl`, and the
-        actual mesh is in `/usr/local/share/ModelName/meshes/mesh.stl`, the `package_dirs` should
-        contain `/usr/local/share`.
+ 
+        If the `package_dirs` argument is provided, the model is also searched in the folders
+        specified in `package_dirs` . In particular if a file is specified by the uri
+        `package://ModelName/meshes/mesh.stl`, and the actual file is in 
+        `/usr/local/share/ModelName/meshes/mesh.stl`, the `package_dirs` should contain `/usr/local/share`.
     """
     package_dirs = package_dirs if isinstance(package_dirs, list) else [package_dirs]
 

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -107,8 +107,8 @@ def resolve_robotics_uri(uri: str, extra_path: str | None = None) -> pathlib.Pat
 
     if uri.startswith("file:"):
         # Strip the scheme from the URI
-        uri = uri.replace(f"file://", "")
-        uri = uri.replace(f"file:", "")
+        uri = uri.replace("file://", "")
+        uri = uri.replace("file:", "")
 
         # Create the file path, resolving symlinks and '..'
         uri_file_path = pathlib.Path(uri).resolve()

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -84,13 +84,21 @@ def resolve_robotics_uri(
 
     Args:
         uri: The URI to resolve.
-        extra_path: Additional environment variable to look for the file.
+        package_dirs: A list of additional paths to look for the file.
 
     Returns:
         The absolute filename corresponding to the URI.
 
     Raises:
         FileNotFoundError: If no file corresponding to the URI is found.
+
+    Note:
+        In case `package_dirs` is not provided, the function will look for the file in the
+        default search paths specified by the environment variables in `SupportedEnvVars`.
+
+        If a given model searches for the meshes in `package://ModelName/meshes/mesh.stl`, and the
+        actual mesh is in `/usr/local/share/ModelName/meshes/mesh.stl`, the `package_dirs` should
+        contain `/usr/local/share`.
     """
     package_dirs = package_dirs if isinstance(package_dirs, list) else [package_dirs]
 

--- a/test/test_resolve_robotics_uri_py.py
+++ b/test/test_resolve_robotics_uri_py.py
@@ -164,10 +164,13 @@ def test_scheme_file():
 
 def test_additional_search_path():
 
+    import tempfile
+    import pathlib
+    import resolve_robotics_uri_py
+
     clear_env_vars()
 
     uri = "model://my_model"
-    extra_path = "MY_SEARCH_PATH"
 
     with tempfile.TemporaryDirectory() as temp_dir:
 
@@ -177,11 +180,5 @@ def test_additional_search_path():
         top_level.touch(exist_ok=True)
 
         # Test resolving a URI with an additional search path
-        with export_env_var(name=extra_path, value=str(temp_dir_path)):
-            result = resolve_robotics_uri_py.resolve_robotics_uri(uri, extra_path)
-            assert result == temp_dir_path / "my_model"
-
-        # Test resolving a URI an additional non-existing search path
-        with export_env_var(name=extra_path, value="/this/path/does/not/exist"):
-            with pytest.raises(FileNotFoundError):
-                resolve_robotics_uri_py.resolve_robotics_uri(uri, extra_path)
+        result = resolve_robotics_uri_py.resolve_robotics_uri(uri, temp_dir)
+        assert result == temp_dir_path / "my_model"


### PR DESCRIPTION
This pull request adds support for custom environment variables as additional search paths when resolving a robotics URI. The `resolve_robotics_uri` function now accepts an optional `extra_path` parameter, which allows users to specify the name of an environment variable associated with a search path. If `extra_path` is provided, the function will include the path associated with the environment variable to the search paths. 

Example usage to find meshes path:

```python
import os
import pathlib

import robot_descriptions.ur10_description
from robot_descriptions._package_dirs import get_package_dirs

from resolve_robotics_uri_py import resolve_robotics_uri

model_urdf_path = pathlib.Path(robot_descriptions.ur10_description.URDF_PATH)

package_dirs = get_package_dirs(robot_descriptions.ur10_description)
mesh_path = resolve_robotics_uri(
    uri="package://example-robot-data/robots/ur_description/meshes/ur10/collision/shoulder.stl",
    package_dirs=package_dirs,
)

print(f"Mesh path: {mesh_path}")
```

Solves #12