### PR TITLE
Ignore empty elements in lists parsed from env vars

### DIFF
--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -43,7 +43,7 @@ SupportedEnvVars = {
 def get_search_paths_from_envs(env_list: Iterable[str]) -> list[pathlib.Path]:
     # Read the searched paths from all the environment variables
     search_paths = [
-        pathlib.Path(f.strip()) if (env != "AMENT_PREFIX_PATH") else pathlib.Path(f) / "share"
+        pathlib.Path(f.strip()) if (env != "AMENT_PREFIX_PATH") else pathlib.Path(f.strip()) / "share"
         for env in env_list
         if os.getenv(env) is not None
         for f in os.getenv(env).split(os.pathsep)
@@ -221,4 +221,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
 

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -43,10 +43,11 @@ SupportedEnvVars = {
 def get_search_paths_from_envs(env_list: Iterable[str]) -> list[pathlib.Path]:
     # Read the searched paths from all the environment variables
     search_paths = [
-        pathlib.Path(f) if (env != "AMENT_PREFIX_PATH") else pathlib.Path(f) / "share"
+        pathlib.Path(f.strip()) if (env != "AMENT_PREFIX_PATH") else pathlib.Path(f) / "share"
         for env in env_list
         if os.getenv(env) is not None
         for f in os.getenv(env).split(os.pathsep)
+        if f.strip() != ""
     ]
 
     # Resolve and remove duplicate paths
@@ -220,3 +221,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -221,5 +221,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-


### PR DESCRIPTION
The following is a valid environment variable:

```bash
ROS_PACKAGE_PATH=/path/to/folder::
```

When this happens, the existing logic populates the following:

https://github.com/ami-iit/resolve-robotics-uri-py/blob/4584ee94bf02b7f79a693dcac9e949655cd8b733/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py#L45-L50

with two extra empty entries:

```
In [1]: "/path/to/folder::".split(":")
Out[1]: ['/path/to/folder', '', '']
```

This PR introduces support for ignoring empty entries.