### PR TITLE
Modify CI workflow for Windows 2022 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-22.04, macos-latest, windows-2019]
+        os: [ubuntu-22.04, macos-latest, windows-2022]
 
     steps:
     - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
     - name: Import the package
       shell: bash -l {0}
       run: python -c "import resolve_robotics_uri_py"
-    
+
     - name: Run the Python tests
       shell: bash -l {0}
       run: pytest --capture=no
@@ -62,3 +62,11 @@ jobs:
         resolve-robotics-uri-py "file:///tmp/folder/file with spaces.txt"
         resolve-robotics-uri-py "file:/tmp/folder/file_without_spaces.txt"
         resolve-robotics-uri-py "file:/tmp/folder/file with spaces.txt"
+    - name: Check command line helper (Windows)
+      if: startsWith(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+          mkdir -p /c/temp/folder
+          echo "test" > /c/temp/folder/file.txt
+          # RFC8089-compliant URI with triple slash and drive letter
+          resolve-robotics-uri-py "file:///C:/temp/folder/file.txt"


### PR DESCRIPTION
This PR updates the Action Runner to Windows 2022 image and adds a tests for #17.