### PR TITLE
Add support for automatically looking into Python install prefix even without setting any env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ absolute_path = resolve_robotics_uri_py.resolve_robotics_uri(
 
 ## Details on how files are searched
 
-You can find the detail how `resolve-robotics-uri-py`  find files in the [rru_spec.md](rru_spec.md) file.
+You can find the details on how `resolve-robotics-uri-py` find files in the [rru_spec.md](rru_spec.md) file.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ If you want to get the location of the `panda`  model installed by [`moveit_reso
 absolute_path = resolve_robotics_uri_py.resolve_robotics_uri("package://moveit_resources_panda_description/urdf/panda.urdf")
 ~~~
 
-
 ## Command Line usage
 
 `resolve_robotics_uri_py` also install a command line tool called `resolve-robotics-uri-py` for use in scripts, that can be used as:
@@ -92,6 +91,11 @@ absolute_path = resolve_robotics_uri_py.resolve_robotics_uri(
      package_dirs=["/path/to/packages", "/another/path"]
 )
 ~~~
+
+## Details on how files are searched
+
+You can find the detail how `resolve-robotics-uri-py`  find files in the [rru_spec.md](rru_spec.md) file.
+
 
 ## Contributing
 

--- a/examples/example_python_package/README.md
+++ b/examples/example_python_package/README.md
@@ -1,0 +1,20 @@
+# example_python_package
+
+This example shows how a pure Python package can install a ROS-style resource into `share/` so
+`resolve_robotics_uri_py` can find it with `package://example_python_package/cube.urdf`.
+
+Install it from this directory with:
+
+```bash
+python -m pip install .
+```
+
+After installation, the URDF is available at:
+
+```python
+resolve_robotics_uri_py.resolve_robotics_uri("package://example_python_package/cube.urdf")
+```
+
+The installed file layout includes `share/example_python_package/cube.urdf`.
+
+This is achieved by installing the `share` folder under the `<distribution>-<version>.data/data/` part of the wheel, that ends up being installed [directly in the python install prefix](https://packaging.python.org/en/latest/specifications/binary-distribution-format/).

--- a/examples/example_python_package/example_python_package/__init__.py
+++ b/examples/example_python_package/example_python_package/__init__.py
@@ -1,0 +1,1 @@
+"""Example package that installs a cube URDF into share/."""

--- a/examples/example_python_package/package.xml
+++ b/examples/example_python_package/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>example_python_package</name>
+  <version>0.1.0</version>
+  <description>Example of a pure python package that installs data files in a way that can be found by resolve-robotics-uri-py and regular ROS tooling.</description>
+  <maintainer email="silvio.traversaro@gbionics.ai">Silvio Traversaro</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <export>
+    <build_type>setuptools</build_type>
+  </export>
+</package>

--- a/examples/example_python_package/pyproject.toml
+++ b/examples/example_python_package/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "example_python_package"
+version = "0.0.0"
+description = "Example pure Python package that installs a URDF into share/"
+
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[tool.setuptools]
+
+include-package-data = true

--- a/examples/example_python_package/setup.py
+++ b/examples/example_python_package/setup.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from setuptools import setup
+
+_SHARE_DIR = Path("share")
+
+
+def _ensure_ament_resource_marker() -> Path:
+    marker = Path("build") / "ament_resource_marker" / "example_python_package"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.touch(exist_ok=True)
+    return marker
+
+
+def _build_data_files() -> list[tuple[str, list[str]]]:
+    """Recursively collect share/ into wheel data-files without manual enumeration."""
+    install_share = Path("share")
+    package_share = install_share / "example_python_package"
+    data_files: dict[str, list[str]] = {}
+    if _SHARE_DIR.is_dir():
+        for path in sorted(_SHARE_DIR.rglob("*")):
+            if not path.is_file():
+                continue
+            rel_dir = path.parent.relative_to(_SHARE_DIR)
+            target = str(install_share / rel_dir)
+            data_files.setdefault(target, []).append(str(path))
+
+    # Install package metadata where ROS tools expect it, but keep it in
+    # the root of the package so colcon can find it when building from source
+    package_xml = Path("package.xml")
+    if package_xml.is_file():
+        data_files.setdefault(str(package_share), []).append(str(package_xml))
+
+    # Install a generated ROS 2 ament index marker file.
+    marker = _ensure_ament_resource_marker()
+    data_files.setdefault(
+        "share/ament_index/resource_index/packages", []
+    ).append(str(marker))
+
+    return sorted(data_files.items())
+
+
+setup(data_files=_build_data_files())

--- a/examples/example_python_package/share/example_python_package/cube.urdf
+++ b/examples/example_python_package/share/example_python_package/cube.urdf
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<robot name="example_cube">
+  <link name="base_link">
+    <inertial>
+      <mass value="1.0"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia ixx="0.0016666667" ixy="0" ixz="0" iyy="0.0016666667" iyz="0" izz="0.0016666667"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0.2 0.4 0.9 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/rru_spec.md
+++ b/rru_spec.md
@@ -1,0 +1,75 @@
+# File Search Rules
+
+`resolve_robotics_uri_py` resolves URIs by following the rules below.
+
+## Supported URI Schemes
+
+The resolver accepts these schemes:
+
+- `file://`
+- `package://`
+- `model://`
+
+If a path is passed without a scheme, it is treated as a local file path and converted to a `file://` URI.
+
+## `file://` Resolution
+
+For `file://` URIs, the path is converted to a local filesystem path and checked directly. The file must exist and be a regular file.
+
+## `package://` and `model://` Resolution
+
+For scoped URIs, the resolver strips the scheme and searches for the remaining relative path under a set of candidate directories.
+
+The search order is:
+
+1. Search paths derived from supported environment variables.
+2. Search paths derived from Python installation prefixes, unless excluded.
+3. Any directories passed explicitly through `package_dirs`.
+
+If multiple matching files are found, the first one in the collected list is returned and a warning is emitted.
+
+## Environment Variables Used For Search
+
+The resolver reads these environment variables by default:
+
+- `AMENT_PREFIX_PATH`
+- `GAZEBO_MODEL_PATH`
+- `GZ_SIM_RESOURCE_PATH`
+- `IGN_GAZEBO_RESOURCE_PATH`
+- `ROS_PACKAGE_PATH`
+- `SDF_PATH`
+- `RRU_ADDITIONAL_PATHS`
+
+Each variable may contain multiple paths separated by `os.pathsep`.
+
+Special handling applies to `AMENT_PREFIX_PATH`: each entry is interpreted as a prefix and `share` is appended before searching.
+
+All other variables are searched as-is.
+
+Non-existing entries are ignored, and a warning is emitted for them.
+
+## Python Prefix Search Paths
+
+By default, the resolver considers two Python installation prefixes:
+
+- `sys.prefix`
+- `sysconfig.get_path("data")`
+
+For each prefix, it searches:
+
+- `<prefix>/share`
+- On Windows only: `<prefix>/Library/share`
+
+This makes it possible to resolve ROS-style resources installed by pure Python packages that place files under `share/<package_name>/`.
+
+You can disable Python-prefix-based search by passing `exclude_python_prefix=True` in Python or `--exclude-python-prefix` on the command line.
+
+## Explicit Additional Directories
+
+The `package_dirs` argument adds extra directories to the search set. Entries may be provided as a list or as a separator-delimited string.
+
+These directories are searched in addition to the default environment-based paths and Python-prefix-based paths.
+
+## Failure Behavior
+
+If no matching file is found, the resolver raises `FileNotFoundError`.

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -77,9 +77,7 @@ def get_default_search_paths(
     exclude_env_vars: Union[list[str], None] = None,
 ) -> list[pathlib.Path]:
     exclude_env_vars = set(exclude_env_vars or [])
-    search_env_vars = [
-        env for env in SupportedEnvVars if env not in exclude_env_vars
-    ]
+    search_env_vars = SupportedEnvVars - exclude_env_vars
     search_paths = get_search_paths_from_envs(search_env_vars)
 
     if not exclude_python_prefix:

--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import pathlib
 import sys
+import sysconfig
 import warnings
 from typing import Union, Iterable
 from urllib.parse import urlparse
@@ -71,6 +72,50 @@ def get_search_paths_from_envs(env_list: Iterable[str]) -> list[pathlib.Path]:
     return existing_search_paths
 
 
+def get_default_search_paths(
+    exclude_python_prefix: bool = False,
+    exclude_env_vars: Union[list[str], None] = None,
+) -> list[pathlib.Path]:
+    exclude_env_vars = set(exclude_env_vars or [])
+    search_env_vars = [
+        env for env in SupportedEnvVars if env not in exclude_env_vars
+    ]
+    search_paths = get_search_paths_from_envs(search_env_vars)
+
+    if not exclude_python_prefix:
+        search_prefixes = {pathlib.Path(sys.prefix).resolve()}
+        sysconfig_data_prefix = sysconfig.get_path("data")
+
+        if sysconfig_data_prefix:
+            search_prefixes.add(pathlib.Path(sysconfig_data_prefix).resolve())
+
+        # Avoid adding duplicate paths when sys.prefix and sysconfig.get_path("data")
+        # map to the same location.
+        seen_paths = {path.resolve() for path in search_paths}
+
+        for prefix in search_prefixes:
+            search_path_candidates = [prefix / "share"]
+
+            # On Windows conda prefixes, data files are installed under
+            # <prefix>/Library/share rather than <prefix>/share.
+            if sys.platform == "win32":
+                search_path_candidates.append(prefix / "Library" / "share")
+
+            for candidate in search_path_candidates:
+                if not candidate.is_dir():
+                    continue
+
+                resolved_candidate = candidate.resolve()
+
+                if resolved_candidate in seen_paths:
+                    continue
+
+                seen_paths.add(resolved_candidate)
+                search_paths.append(resolved_candidate)
+
+    return search_paths
+
+
 def pathlist_list_to_string(path_list: Iterable[Union[str, pathlib.Path]]) -> str:
     return " ".join(str(path) for path in path_list)
 
@@ -81,7 +126,10 @@ def pathlist_list_to_string(path_list: Iterable[Union[str, pathlib.Path]]) -> st
 
 
 def resolve_robotics_uri(
-    uri: str, package_dirs: Union[list[str], None] = None
+    uri: str,
+    package_dirs: Union[list[str], None] = None,
+    exclude_python_prefix: bool = False,
+    exclude_env_vars: Union[list[str], None] = None,
 ) -> pathlib.Path:
     """
     Resolve a robotics URI to an absolute filename.
@@ -89,6 +137,9 @@ def resolve_robotics_uri(
     Args:
         uri: The URI to resolve.
         package_dirs: A list of additional paths to look for the file.
+        exclude_python_prefix: If True, do not search Python installation prefixes.
+        exclude_env_vars: Optional list of environment variable names to exclude from
+            the default search path list.
 
     Returns:
         The absolute filename corresponding to the URI.
@@ -156,7 +207,9 @@ def resolve_robotics_uri(
     model_filenames = []
 
     # Search the resource in the path from the env variables
-    for folder in set(get_search_paths_from_envs(SupportedEnvVars)) | {
+    for folder in set(
+        get_default_search_paths(exclude_python_prefix, exclude_env_vars)
+    ) | {
         path
         for directory in package_dirs
         if directory and (path := pathlib.Path(directory).expanduser()).exists()
@@ -202,11 +255,30 @@ def main():
         help="Additional paths to look for the file",
         default=None,
     )
+    parser.add_argument(
+        "--exclude-python-prefix",
+        action="store_true",
+        help="Do not search Python installation prefixes",
+    )
+    parser.add_argument(
+        "--exclude-env-var",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="Exclude an environment variable from the default search path list",
+    )
 
     args = parser.parse_args()
 
+    exclude_env_vars = set(args.exclude_env_var)
+
     try:
-        result = resolve_robotics_uri(args.uri, args.package_dirs)
+        result = resolve_robotics_uri(
+            args.uri,
+            args.package_dirs,
+            exclude_python_prefix=args.exclude_python_prefix,
+            exclude_env_vars=list(exclude_env_vars),
+        )
     except FileNotFoundError as e:
         print(e, file=sys.stderr)
         sys.exit(1)

--- a/test/test_default_search_paths.py
+++ b/test/test_default_search_paths.py
@@ -1,0 +1,54 @@
+import pathlib
+import tempfile
+
+import resolve_robotics_uri_py
+
+
+def _clear_supported_env_vars(monkeypatch):
+    for env_var in resolve_robotics_uri_py.resolve_robotics_uri_py.SupportedEnvVars:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_default_search_paths_include_sysconfig_data_prefix(monkeypatch):
+    _clear_supported_env_vars(monkeypatch)
+
+    with tempfile.TemporaryDirectory() as sys_prefix_dir, tempfile.TemporaryDirectory() as data_prefix_dir:
+        sys_prefix_path = pathlib.Path(sys_prefix_dir).resolve()
+        data_prefix_path = pathlib.Path(data_prefix_dir).resolve()
+
+        sys_prefix_share = sys_prefix_path / "share"
+        data_prefix_share = data_prefix_path / "share"
+        sys_prefix_share.mkdir(parents=True, exist_ok=True)
+        data_prefix_share.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(resolve_robotics_uri_py.resolve_robotics_uri_py.sys, "prefix", str(sys_prefix_path))
+        monkeypatch.setattr(
+            resolve_robotics_uri_py.resolve_robotics_uri_py.sysconfig,
+            "get_path",
+            lambda name, *args, **kwargs: str(data_prefix_path) if name == "data" else None,
+        )
+
+        search_paths = resolve_robotics_uri_py.resolve_robotics_uri_py.get_default_search_paths()
+
+        assert sys_prefix_share in search_paths
+        assert data_prefix_share in search_paths
+
+
+def test_default_search_paths_deduplicate_same_prefix(monkeypatch):
+    _clear_supported_env_vars(monkeypatch)
+
+    with tempfile.TemporaryDirectory() as common_prefix_dir:
+        common_prefix_path = pathlib.Path(common_prefix_dir).resolve()
+        common_share = common_prefix_path / "share"
+        common_share.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(resolve_robotics_uri_py.resolve_robotics_uri_py.sys, "prefix", str(common_prefix_path))
+        monkeypatch.setattr(
+            resolve_robotics_uri_py.resolve_robotics_uri_py.sysconfig,
+            "get_path",
+            lambda name, *args, **kwargs: str(common_prefix_path) if name == "data" else None,
+        )
+
+        search_paths = resolve_robotics_uri_py.resolve_robotics_uri_py.get_default_search_paths()
+
+        assert search_paths.count(common_share) == 1

--- a/test/test_resolve_robotics_uri_py.py
+++ b/test/test_resolve_robotics_uri_py.py
@@ -200,17 +200,17 @@ def test_additional_search_path():
 
 def test_sys_prefix_search_and_opt_out(monkeypatch):
 
-        clear_env_vars()
+    clear_env_vars()
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-                temp_dir_path = pathlib.Path(temp_dir).resolve()
-                share_dir = temp_dir_path / "share"
-                package_dir = share_dir / "example_python_package"
-                package_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_path = pathlib.Path(temp_dir).resolve()
+        share_dir = temp_dir_path / "share"
+        package_dir = share_dir / "example_python_package"
+        package_dir.mkdir(parents=True, exist_ok=True)
 
-                cube_urdf = package_dir / "cube.urdf"
-                cube_urdf.write_text(
-                        """<?xml version=\"1.0\"?>
+        cube_urdf = package_dir / "cube.urdf"
+        cube_urdf.write_text(
+            """<?xml version=\"1.0\"?>
 <robot name=\"example_cube\">
     <link name=\"base_link\">
         <visual>
@@ -221,53 +221,56 @@ def test_sys_prefix_search_and_opt_out(monkeypatch):
     </link>
 </robot>
 """,
-                        encoding="utf-8",
-                )
+            encoding="utf-8",
+        )
 
-                monkeypatch.setattr(resolve_robotics_uri_py.resolve_robotics_uri_py.sys, "prefix", temp_dir)
-                monkeypatch.setattr(
-                    resolve_robotics_uri_py.resolve_robotics_uri_py.sysconfig,
-                    "get_path",
-                    lambda name, *args, **kwargs: temp_dir if name == "data" else None,
-                )
+        monkeypatch.setattr(resolve_robotics_uri_py.resolve_robotics_uri_py.sys, "prefix", temp_dir)
+        monkeypatch.setattr(
+            resolve_robotics_uri_py.resolve_robotics_uri_py.sysconfig,
+            "get_path",
+            lambda name, *args, **kwargs: temp_dir if name == "data" else None,
+        )
 
-                uri = "package://example_python_package/cube.urdf"
+        uri = "package://example_python_package/cube.urdf"
 
-                result = resolve_robotics_uri_py.resolve_robotics_uri(uri)
-                assert result == cube_urdf
+        result = resolve_robotics_uri_py.resolve_robotics_uri(uri)
+        assert result == cube_urdf
 
-                with pytest.raises(FileNotFoundError):
-                    resolve_robotics_uri_py.resolve_robotics_uri(uri, exclude_python_prefix=True)
+        with pytest.raises(FileNotFoundError):
+            resolve_robotics_uri_py.resolve_robotics_uri(
+                uri,
+                exclude_python_prefix=True,
+            )
 
-                result = resolve_robotics_uri_py.resolve_robotics_uri(
-                        uri,
-                        package_dirs=[str(share_dir)],
-                    exclude_python_prefix=True,
-                )
-                assert result == cube_urdf
+        result = resolve_robotics_uri_py.resolve_robotics_uri(
+            uri,
+            package_dirs=[str(share_dir)],
+            exclude_python_prefix=True,
+        )
+        assert result == cube_urdf
 
 
-        def test_exclude_env_vars(monkeypatch):
+def test_exclude_env_vars(monkeypatch):
 
-            clear_env_vars()
+    clear_env_vars()
 
-            with tempfile.TemporaryDirectory() as temp_dir:
-                temp_dir_path = pathlib.Path(temp_dir).resolve()
-                model_dir = temp_dir_path / "gazebo_models"
-                model_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_path = pathlib.Path(temp_dir).resolve()
+        model_dir = temp_dir_path / "gazebo_models"
+        model_dir.mkdir(parents=True, exist_ok=True)
 
-                model_file = model_dir / "example_model"
-                model_file.touch(exist_ok=True)
+        model_file = model_dir / "example_model"
+        model_file.touch(exist_ok=True)
 
-                monkeypatch.setenv("GAZEBO_MODEL_PATH", str(model_dir))
+        monkeypatch.setenv("GAZEBO_MODEL_PATH", str(model_dir))
 
-                uri = "model://example_model"
+        uri = "model://example_model"
 
-                result = resolve_robotics_uri_py.resolve_robotics_uri(uri)
-                assert result == model_file
+        result = resolve_robotics_uri_py.resolve_robotics_uri(uri)
+        assert result == model_file
 
-                with pytest.raises(FileNotFoundError):
-                    resolve_robotics_uri_py.resolve_robotics_uri(
-                        uri,
-                        exclude_env_vars=["GAZEBO_MODEL_PATH"],
-                    )
+        with pytest.raises(FileNotFoundError):
+            resolve_robotics_uri_py.resolve_robotics_uri(
+                uri,
+                exclude_env_vars=["GAZEBO_MODEL_PATH"],
+            )

--- a/test/test_resolve_robotics_uri_py.py
+++ b/test/test_resolve_robotics_uri_py.py
@@ -46,7 +46,7 @@ def test_scoped_uri(scheme: str, env_var_name="GZ_SIM_RESOURCE_PATH"):
     # Existing URI path not in search dirs
     with pytest.raises(FileNotFoundError):
         with tempfile.NamedTemporaryFile() as temp:
-            uri = f"{scheme}{temp.name}"
+            uri = f"{scheme}{pathlib.Path(temp.name).name}"
             resolve_robotics_uri_py.resolve_robotics_uri(uri)
 
     # URI path in top-level search dir
@@ -196,3 +196,78 @@ def test_additional_search_path():
         ):
             result = resolve_robotics_uri_py.resolve_robotics_uri(uri)
             assert result == temp_dir_path / "my_model"
+
+
+def test_sys_prefix_search_and_opt_out(monkeypatch):
+
+        clear_env_vars()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+                temp_dir_path = pathlib.Path(temp_dir).resolve()
+                share_dir = temp_dir_path / "share"
+                package_dir = share_dir / "example_python_package"
+                package_dir.mkdir(parents=True, exist_ok=True)
+
+                cube_urdf = package_dir / "cube.urdf"
+                cube_urdf.write_text(
+                        """<?xml version=\"1.0\"?>
+<robot name=\"example_cube\">
+    <link name=\"base_link\">
+        <visual>
+            <geometry>
+                <box size=\"0.1 0.1 0.1\"/>
+            </geometry>
+        </visual>
+    </link>
+</robot>
+""",
+                        encoding="utf-8",
+                )
+
+                monkeypatch.setattr(resolve_robotics_uri_py.resolve_robotics_uri_py.sys, "prefix", temp_dir)
+                monkeypatch.setattr(
+                    resolve_robotics_uri_py.resolve_robotics_uri_py.sysconfig,
+                    "get_path",
+                    lambda name, *args, **kwargs: temp_dir if name == "data" else None,
+                )
+
+                uri = "package://example_python_package/cube.urdf"
+
+                result = resolve_robotics_uri_py.resolve_robotics_uri(uri)
+                assert result == cube_urdf
+
+                with pytest.raises(FileNotFoundError):
+                    resolve_robotics_uri_py.resolve_robotics_uri(uri, exclude_python_prefix=True)
+
+                result = resolve_robotics_uri_py.resolve_robotics_uri(
+                        uri,
+                        package_dirs=[str(share_dir)],
+                    exclude_python_prefix=True,
+                )
+                assert result == cube_urdf
+
+
+        def test_exclude_env_vars(monkeypatch):
+
+            clear_env_vars()
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_dir_path = pathlib.Path(temp_dir).resolve()
+                model_dir = temp_dir_path / "gazebo_models"
+                model_dir.mkdir(parents=True, exist_ok=True)
+
+                model_file = model_dir / "example_model"
+                model_file.touch(exist_ok=True)
+
+                monkeypatch.setenv("GAZEBO_MODEL_PATH", str(model_dir))
+
+                uri = "model://example_model"
+
+                result = resolve_robotics_uri_py.resolve_robotics_uri(uri)
+                assert result == model_file
+
+                with pytest.raises(FileNotFoundError):
+                    resolve_robotics_uri_py.resolve_robotics_uri(
+                        uri,
+                        exclude_env_vars=["GAZEBO_MODEL_PATH"],
+                    )


### PR DESCRIPTION
## Overview

When working with virtual environments (both in Python's native `venv` or in conda-style environments) it is a bit pointless to have to set environment variables like `AMENT_PREFIX_PATH` or `GZ_SIM_RESOURCE_PATH`, when the packages that are installed are installed in the root of the virtual environment.

To reduce the amount of time friction of when it is necessary to set `AMENT_PREFIX_PATH` or `GZ_SIM_RESOURCE_PATH`, this PR modifies `resolve-robotics-uri-py` to also search automatically:
* The share subfolder of the python install prefix (obtained via `sys.prefix` or `sysconfig.get_path("data")`, that in the vast majority of cases are the same folder)
* Only on Windows, the `share/Library` subfolder of the python install prefix, to support also how C++/non-Python packages are installed in conda on Windows

This for example permits to install models (or in general any file accessible via `package://` URIs) as part of pure python wheels in a virtual environment, and to find such models without the need to set any environment variable.

## Other modifications of the PR

Some other modifications are included in the PR, as they were useful for this change. The only modifications that are really important are the modification (that are relatively limited) to the `src/resolve_robotics_uri_py/resolve_robotics_uri_py.py` file.

### Specification of resolve-robotics-uri search logic

As the search logic was already complex, and it became more complex with this PR, the `rru_spec.md` file has been added to describe in detail how files are searched by `resolve-robotics-uri-py`.

### `examples/example_python_package`

An example of a Python package that installs files via the `<distribution>-<version>.data/data/` part of the wheel, and that it can be found via the new functionality introduced in this PR.

### Options to opt-out for some search logic

As some users may not want to search for files in python install prefix, so option `exclude_python_prefix` has been added, that can be set to false if you do not want to search for Python install prefix.
 
## Editable install

Note that in general data files are not installed in editable mode even if the package containing them is installed in editable mode (in a nutshell, only python files are installed in editable mode) so this logic does not contain any special logic for supporting packages that are installed in editable mode, as in that case the `<distribution>-<version>.data/data/` part of the wheel (the one that contains files that end up installed in the python prefix) is always installed in editable mode.