### PR TITLE
Allow finding directories with package://<something> URIs

### DIFF
--- a/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
+++ b/src/resolve_robotics_uri_py/resolve_robotics_uri_py.py
@@ -218,7 +218,7 @@ def resolve_robotics_uri(
         # Expand or resolve the file path (symlinks and ..)
         candidate_file_name = candidate_file_name.resolve()
 
-        if not candidate_file_name.is_file():
+        if not candidate_file_name.exists():
             continue
 
         # Skip if the file is already in the list

--- a/test/test_resolve_robotics_uri_py.py
+++ b/test/test_resolve_robotics_uri_py.py
@@ -274,3 +274,21 @@ def test_exclude_env_vars(monkeypatch):
                 uri,
                 exclude_env_vars=["GAZEBO_MODEL_PATH"],
             )
+
+
+def test_package_scheme_package_root_directory_resolution(monkeypatch):
+
+    clear_env_vars()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_path = pathlib.Path(temp_dir).resolve()
+        package_dir = temp_dir_path / "example_package"
+        package_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setenv("GZ_SIM_RESOURCE_PATH", str(temp_dir_path))
+
+        result = resolve_robotics_uri_py.resolve_robotics_uri(
+            "package://example_package"
+        )
+
+        assert result == package_dir


### PR DESCRIPTION
Before this PR, searching for a folder via `package://<something>`, as the candidate path was not checked for existence, but it was checked if it was actually a file. This condition is relaxed here, to ensure that also folders can be found with `package://<something>` URIs.